### PR TITLE
Forces git checkout even when conflicts / force pushes happen

### DIFF
--- a/builder.rb
+++ b/builder.rb
@@ -47,7 +47,7 @@ class Builder
   def self.git_checkout(repo)
     Resque.logger.info "repo exists, pulling #{repo.url}"
     Dir.chdir(repo.dir) do
-      %x[ git checkout #{repo.branch} && git pull ]
+      %x[ git checkout #{repo.branch} && git fetch && git reset --hard origin/#{repo.branch} ]
     end
   end
 


### PR DESCRIPTION
Hi @rlister,

Because `git pull` can fail in some cases, I believe doing a `fetch`, then `reset --hard` is better.

We could also investigate bare repositories, which don't care about local state of things, just SHAs.

Cheers.
