### PR TITLE
Forces checkout to ignore local unmerged files

### DIFF
--- a/builder.rb
+++ b/builder.rb
@@ -47,7 +47,7 @@ class Builder
   def self.git_checkout(repo)
     Resque.logger.info "repo exists, pulling #{repo.url}"
     Dir.chdir(repo.dir) do
-      %x[ git checkout #{repo.branch} && git fetch && git reset --hard origin/#{repo.branch} ]
+      %x[ git checkout -f #{repo.branch} && git fetch && git reset --hard origin/#{repo.branch} ]
     end
   end
 


### PR DESCRIPTION
Hi @rlister,

This adds the `-f` flag in case there are local changes or unmerged files inside builder_beer repo.

Cheers
